### PR TITLE
Added the ability to pass request headers to commands

### DIFF
--- a/src/Test/WebDriver/Class.hs
+++ b/src/Test/WebDriver/Class.hs
@@ -4,12 +4,13 @@ module Test.WebDriver.Class
        ( -- * WebDriver class
          WebDriver(..), Method, methodDelete, methodGet, methodPost,
        ) where
-import Test.WebDriver.Session 
+import Test.WebDriver.Session
 
 import Data.Aeson
 import Data.Text (Text)
 
 import Network.HTTP.Types.Method (methodDelete, methodGet, methodPost, Method)
+import Network.HTTP.Types.Header (RequestHeaders)
 
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Identity
@@ -26,49 +27,50 @@ import Control.Monad.RWS.Lazy as LRWS
 
 
 
-  
+
 -- |A class for monads that can handle wire protocol requests. This is the
 -- operation underlying all of the high-level commands exported in
 -- "Test.WebDriver.Commands". For more information on the wire protocol see
 -- <http://code.google.com/p/selenium/wiki/JsonWireProtocol>
 class (WDSessionState wd) => WebDriver wd where
   doCommand :: (ToJSON a, FromJSON b) =>
-                Method        -- ^HTTP request method
-                -> Text       -- ^URL of request
-                -> a          -- ^JSON parameters passed in the body
-                              -- of the request. Note that, as a special case,
-                              -- anything that converts to Data.Aeson.Null will
-                              -- result in an empty request body.
-                -> wd b       -- ^The JSON result of the HTTP request.
+                RequestHeaders -- ^Additional headers
+                -> Method      -- ^HTTP request method
+                -> Text        -- ^URL of request
+                -> a           -- ^JSON parameters passed in the body
+                               -- of the request. Note that, as a special case,
+                               -- anything that converts to Data.Aeson.Null will
+                               -- result in an empty request body.
+                -> wd b        -- ^The JSON result of the HTTP request.
 
 instance WebDriver wd => WebDriver (SS.StateT s wd) where
-  doCommand rm t a = lift (doCommand rm t a)
-  
+  doCommand rh rm t a = lift (doCommand rh rm t a)
+
 instance WebDriver wd => WebDriver (LS.StateT s wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 
 instance WebDriver wd => WebDriver (MaybeT wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 
 instance WebDriver wd => WebDriver (IdentityT wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 
 instance (Monoid w, WebDriver wd) => WebDriver (LW.WriterT w wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 
 instance WebDriver wd => WebDriver (ReaderT r wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 instance (Error e, WebDriver wd) => WebDriver (ErrorT e wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 
 instance (Monoid w, WebDriver wd) => WebDriver (SRWS.RWST r w s wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)
 
 instance (Monoid w, WebDriver wd) => WebDriver (LRWS.RWST r w s wd) where
-  doCommand rm t a = lift (doCommand rm t a)
+  doCommand rh rm t a = lift (doCommand rh rm t a)

--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -91,6 +91,7 @@ import Data.ByteString.Lazy as LBS (ByteString)
 import Network.URI hiding (path)  -- suppresses warnings
 import Codec.Archive.Zip
 import qualified Data.Text.Lazy.Encoding as TL
+import Network.HTTP.Types.Header (RequestHeaders)
 
 import Control.Applicative
 import Control.Monad.State.Strict
@@ -112,15 +113,15 @@ ignoreReturn :: WebDriver wd => wd Value -> wd ()
 ignoreReturn = void
 
 -- |Create a new session with the given 'Capabilities'.
-createSession :: WebDriver wd => Capabilities -> wd WDSession
-createSession caps = do
-  ignoreReturn . doCommand methodPost "/session" . single "desiredCapabilities" $ caps
+createSession :: WebDriver wd => RequestHeaders -> Capabilities -> wd WDSession
+createSession headers caps = do
+  ignoreReturn . doCommand headers methodPost "/session" . single "desiredCapabilities" $ caps
   getSession
 
 -- |Retrieve a list of active sessions and their 'Capabilities'.
-sessions :: WebDriver wd => wd [(SessionId, Capabilities)]
-sessions = do
-  objs <- doCommand methodGet "/sessions" Null
+sessions :: WebDriver wd => RequestHeaders -> wd [(SessionId, Capabilities)]
+sessions headers = do
+  objs <- doCommand headers methodGet "/sessions" Null
   forM objs $ parsePair "id" "capabilities" "sessions"
 
 -- |Get the actual 'Capabilities' of the current session.
@@ -739,8 +740,8 @@ doStorageCommand m s path a = doSessCommand m (T.concat ["/", s', path]) a
 -- |Get information from the server as a JSON 'Object'. For more information
 -- about this object see
 -- <http://code.google.com/p/selenium/wiki/JsonWireProtocol#/status>
-serverStatus :: (WebDriver wd) => wd Value   -- todo: make this a record type
-serverStatus = doCommand methodGet "/status" Null
+serverStatus :: (WebDriver wd) => RequestHeaders -> wd Value   -- todo: make this a record type
+serverStatus headers = doCommand headers methodGet "/status" Null
 
 -- |A record that represents a single log entry.
 data LogEntry =

--- a/src/Test/WebDriver/Commands/Internal.hs
+++ b/src/Test/WebDriver/Commands/Internal.hs
@@ -73,7 +73,7 @@ doSessCommand method path args = do
         where
           msg = "doSessCommand: No session ID found for relative URL "
                 ++ show path
-      Just (SessionId sId) -> doCommand method
+      Just (SessionId sId) -> doCommand [] method
                               (T.concat ["/session/", urlEncode sId, path]) args
 
 -- |A wrapper around 'doSessCommand' to create element URLs.

--- a/src/Test/WebDriver/Config.hs
+++ b/src/Test/WebDriver/Config.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleContexts #-}
 module Test.WebDriver.Config(
     -- * WebDriver configuration
-    WDConfig(..), defaultConfig, mkSession   
+    WDConfig(..), defaultConfig, mkSession
     ) where
 import Test.WebDriver.Session
 import Test.WebDriver.Capabilities
@@ -9,7 +9,8 @@ import Test.WebDriver.Capabilities
 import Data.Default (Default, def)
 import Data.String (fromString)
 
-import Network.HTTP.Client (Manager, newManager, defaultManagerSettings) 
+import Network.HTTP.Client (Manager, newManager, defaultManagerSettings)
+import Network.HTTP.Types (RequestHeaders)
 
 import Control.Monad.Base (MonadBase, liftBase)
 
@@ -20,6 +21,8 @@ data WDConfig = WDConfig {
       wdHost :: String
      -- |Port number of the server (default 4444)
     , wdPort :: Int
+     -- |Additional request headers to send to the server (default [])
+    , wdRequestHeaders :: RequestHeaders
      -- |Capabilities to use for this session
     , wdCapabilities :: Capabilities
      -- |Whether or not we should keep a history of HTTP requests/responses
@@ -38,18 +41,19 @@ instance Default WDConfig where
     def = WDConfig {
       wdHost              = "127.0.0.1"
     , wdPort              = 4444
+    , wdRequestHeaders    = []
     , wdCapabilities      = def
-    , wdKeepSessHist      = False 
+    , wdKeepSessHist      = False
     , wdBasePath          = "/wd/hub"
     , wdHTTPManager       = Nothing
     }
-    
+
 {- |A default session config connects to localhost on port 4444, and hasn't been
 initialized server-side. This value is the same as 'def' but with a less
 polymorphic type. -}
 defaultConfig :: WDConfig
 defaultConfig = def
-    
+
 -- |Constructs a new 'WDSession' from a given 'WDConfig'
 mkSession :: MonadBase IO m => WDConfig -> m WDSession
 mkSession WDConfig{..} = do
@@ -66,9 +70,9 @@ mkSession WDConfig{..} = do
     histUpdate
       | wdKeepSessHist = (:)
       | otherwise      = \x _ -> [x]
-  
 
 
-    
+
+
 
 

--- a/src/Test/WebDriver/Monad.hs
+++ b/src/Test/WebDriver/Monad.hs
@@ -53,8 +53,8 @@ instance WDSessionState WD where
   putSession = WD . put
 
 instance WebDriver WD where
-  doCommand method path args =
-    mkRequest [] method path args
+  doCommand headers method path args =
+    mkRequest headers method path args
     >>= sendHTTPRequest
     >>= getJSONResult
     >>= either throwIO return
@@ -71,7 +71,7 @@ runWD sess (WD wd) = evalStateT wd sess
 runSession :: WDConfig -> WD a -> IO a
 runSession conf wd = do
   sess <- mkSession conf
-  runWD sess $ createSession (wdCapabilities conf) >> wd
+  runWD sess $ createSession (wdRequestHeaders conf) (wdCapabilities conf) >> wd
 
 -- |Locally sets a 'WDSession' for use within the given 'WD' action.
 -- The state of the outer action is unaffected by this function.


### PR DESCRIPTION
Request headers are needed to send authentication credentials to some remote servers (eg saucelabs). This lets users add these headers (as well as others).