### PR TITLE
Chrome capability handling seems broken

### DIFF
--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -158,12 +158,14 @@ instance ToJSON Capabilities where
              ,"firefox_binary" .= ffBinary
              ]
         Chrome {..}
-          -> catMaybes [ opt "chrome.chromedriverVersion" chromeDriverVersion
-                       , opt "chrome.binary" chromeBinary
-                       ]
-             ++ ["chrome.switches" .= chromeOptions
-                ,"chrome.extensions" .= chromeExtensions
-                ]
+          -> catMaybes [ opt "chrome.chromedriverVersion" chromeDriverVersion ]
+             ++ [ "chromeOptions" .= object (catMaybes
+                  [ opt "binary" chromeBinary
+                  ] ++
+                  [ "args"       .= chromeOptions
+                  , "extensions" .= chromeExtensions
+                  ]
+                )]
         IE {..}
           -> ["ignoreProtectedModeSettings" .= ieIgnoreProtectedModeSettings
              ,"ignoreZoomSetting" .= ieIgnoreZoomSetting


### PR DESCRIPTION
Chrome options should be passed in the capabilities as
{... , "chromeOptions": {"binary":"...", "args":["...", ...]}, ... }.

(https://sites.google.com/a/chromium.org/chromedriver/capabilities for details)

