### PR TITLE
Support GHC 7.10

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings, ScopedTypeVariables, ExistentialQuantification,
-             TemplateHaskell, RecordWildCards #-}
+             TemplateHaskell, RecordWildCards, FlexibleContexts #-}
 -- |This module exports basic WD actions that can be used to interact with a
 -- browser session.
 module Test.WebDriver.Commands


### PR DESCRIPTION
The only thing required is to add the FlexibleContexts extension since GHC 7.10 forces all extensions to be explicit.  There are a bunch of warnings now about unused imports which I did not fix, since this would break older GHCs.  You could wrap the imports in a CPP macro checking the version of base, but I don't know if that is worth it. 