### PR TITLE
ToJSON NoReturn now supports empty string as a form of NoReturn

### DIFF
--- a/src/Test/WebDriver/JSON.hs
+++ b/src/Test/WebDriver/JSON.hs
@@ -58,6 +58,7 @@ data NoReturn = NoReturn
 instance FromJSON NoReturn where
   parseJSON Null                    = return NoReturn
   parseJSON (Object o) | HM.null o  = return NoReturn
+  parseJSON (String "")             = return NoReturn
   parseJSON other                   = typeMismatch "no return value" other
 
 

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -1,5 +1,5 @@
 Name: webdriver
-Version: 0.6.1
+Version: 0.6.1.7569
 Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE


### PR DESCRIPTION
I've been using hs-webdriver in combination with SauceLabs for front end testing. This is a simple change that I feel makes the library a bit more universal without sacrificing any functionality or current versatility. The problem is when running automation tests on SauceLabs, many webdriver commands ran on a SauceLabs VM returns an empty string "". Without this line of code, no further exception handling seemed possible to me because the only error getting thrown was the one thrown by typeMismatch in the JSON NoReturn instance