### PR TITLE
Bump upper bounds on aeson, attoparsec & vector

### DIFF
--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -53,7 +53,7 @@ library
                  , temporary >= 1.0 && < 2.0
                  , time == 1.*
                  , unordered-containers >= 0.1.3 && < 0.4
-                 , vector >= 0.3 && < 0.11
+                 , vector >= 0.3 && < 0.12
                  , exceptions >= 0.4 && < 0.9
                  , scientific >= 0.2 && < 0.4
                  , data-default >= 0.2 && < 1.0

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -34,12 +34,12 @@ library
   hs-source-dirs: src
   ghc-options: -Wall
   build-depends:   base == 4.*
-                 , aeson >= 0.6.2.0 && < 0.9
+                 , aeson >= 0.6.2.0 && < 0.10
                  , http-client >= 0.3 && < 0.5
                  , http-types >= 0.8 && < 0.9
                  , text >= 0.11.3 && < 1.3
                  , bytestring >= 0.9 && < 0.11
-                 , attoparsec < 0.13
+                 , attoparsec < 0.14
                  , base64-bytestring >= 1.0 && < 1.1
                  , mtl >= 2.0 && < 2.3
                  , transformers >= 0.2 && < 0.5


### PR DESCRIPTION
They are all non-breaking updates, and will allow stackage to upgrade its aeson & attoparsec versions (see fpco/stackage#572) and vector version (see https://github.com/fpco/stackage/issues/682)