### PR TITLE
Http retries

### DIFF
--- a/src/Test/WebDriver/Config.hs
+++ b/src/Test/WebDriver/Config.hs
@@ -34,6 +34,8 @@ data WDConfig = WDConfig {
     , wdBasePath :: String
      -- |Use the given http-client 'Manager' instead of the default
     , wdHTTPManager :: Maybe Manager
+     -- |Number of times to retry a HTTP request if it times out
+    , wdHTTPRetryCount :: Int
 
 }
 
@@ -46,6 +48,7 @@ instance Default WDConfig where
     , wdKeepSessHist      = False
     , wdBasePath          = "/wd/hub"
     , wdHTTPManager       = Nothing
+    , wdHTTPRetryCount    = 0
     }
 
 {- |A default session config connects to localhost on port 4444, and hasn't been
@@ -64,7 +67,8 @@ mkSession WDConfig{..} = do
                    , wdSessId = Nothing
                    , wdSessHist = []
                    , wdSessHistUpdate = histUpdate
-                   , wdSessHTTPManager = manager }
+                   , wdSessHTTPManager = manager
+                   , wdSessHTTPRetryCount = wdHTTPRetryCount }
   where
     createManager = liftBase $ newManager defaultManagerSettings
     histUpdate

--- a/src/Test/WebDriver/Config.hs
+++ b/src/Test/WebDriver/Config.hs
@@ -34,7 +34,7 @@ data WDConfig = WDConfig {
     , wdBasePath :: String
      -- |Use the given http-client 'Manager' instead of the default
     , wdHTTPManager :: Maybe Manager
-     -- |Number of times to retry a HTTP request if it times out
+     -- |Number of times to retry a HTTP request if it times out (default 0)
     , wdHTTPRetryCount :: Int
 
 }

--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -68,7 +68,7 @@ mkRequest headers meth wdPath args = do
 sendHTTPRequest :: (WDSessionState s) => Request -> s (Response ByteString)
 sendHTTPRequest req = do
   s@WDSession{..} <- getSession
-  res <- liftBase $ retryOnTimeout 10 $ httpLbs req wdSessHTTPManager
+  res <- liftBase $ retryOnTimeout wdSessHTTPRetryCount $ httpLbs req wdSessHTTPManager
   putSession s {wdSessHist = wdSessHistUpdate (req, res) wdSessHist} 
   return res
 

--- a/src/Test/WebDriver/Session.hs
+++ b/src/Test/WebDriver/Session.hs
@@ -60,6 +60,9 @@ data WDSession = WDSession {
                                                  -> [(Request, Response LBS.ByteString)]
                              -- |HTTP 'Manager' used for connection pooling by the http-client library.
                            , wdSessHTTPManager :: Manager
+
+                             -- |Number of times to retry a HTTP request if it times out
+                           , wdSessHTTPRetryCount :: Int
                            }
     
 -- |The last HTTP request issued by this session, if any.

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -1,5 +1,5 @@
 Name: webdriver
-Version: 0.6.2.1
+Version: 0.6.2.1.1
 Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE


### PR DESCRIPTION
Tearing my hair out over this one. Sometimes Chrome just seems not to completely start up, which makes my tests fail with a ResponseTimeout exception. It seems to have got more frequent with a recent Chrome update - almost every test run has at least one session which fails to start up correctly.

This is a sticking-plaster approach - just retry the request if it times out, and only give up if it fails 10 times in a row. PR opened for discussion in case you know of a better way to do this, rather than because I think it's a serious long-term fix.

Cheers,

David


