### PR TITLE
PAC proxy: new JSON-name for path to PAC-file

### DIFF
--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -630,7 +630,7 @@ instance ToJSON ProxyType where
       ["proxyType" .= ("AUTODETECT" :: String)]
     PAC{autoConfigUrl = url} ->
       ["proxyType" .= ("PAC" :: String)
-      ,"autoConfigUrl" .= url
+      ,"proxyAutoconfigUrl" .= url
       ]
     Manual{ftpProxy = ftp, sslProxy = ssl, httpProxy = http} ->
       ["proxyType" .= ("MANUAL" :: String)

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -1,5 +1,5 @@
 Name: webdriver
-Version: 0.8.0.4
+Version: 0.8.0.5
 Cabal-Version: >= 1.10
 License: BSD3
 License-File: LICENSE


### PR DESCRIPTION
Based on https://code.google.com/p/selenium/wiki/JsonWireProtocol#Proxy_JSON_Object.