### PR TITLE
Added WebDriver and WDSessionState instances for ExceptT

### DIFF
--- a/src/Test/WebDriver/Class.hs
+++ b/src/Test/WebDriver/Class.hs
@@ -23,6 +23,7 @@ import Control.Monad.Trans.Identity
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 --import Control.Monad.Cont
 import Control.Monad.Trans.Writer.Strict as SW
 import Control.Monad.Trans.Writer.Lazy as LW
@@ -72,6 +73,9 @@ instance WebDriver wd => WebDriver (ReaderT r wd) where
   doCommand rm t a = lift (doCommand rm t a)
 
 instance (Error e, WebDriver wd) => WebDriver (ErrorT e wd) where
+  doCommand rm t a = lift (doCommand rm t a)
+
+instance WebDriver wd => WebDriver (ExceptT e wd) where
   doCommand rm t a = lift (doCommand rm t a)
 
 

--- a/src/Test/WebDriver/Session.hs
+++ b/src/Test/WebDriver/Session.hs
@@ -33,6 +33,7 @@ import Control.Monad.Trans.Identity
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 --import Control.Monad.Cont
 import Control.Monad.Trans.Writer.Strict as SW
 import Control.Monad.Trans.Writer.Lazy as LW
@@ -196,7 +197,11 @@ instance WDSessionState m => WDSessionState (ReaderT r m) where
 instance (Error e, WDSessionState m) => WDSessionState (ErrorT e m) where
   getSession = lift getSession
   putSession = lift . putSession
-  
+
+instance WDSessionState m => WDSessionState (ExceptT r m) where
+  getSession = lift getSession
+  putSession = lift . putSession
+
 instance (Monoid w, WDSessionState m) => WDSessionState (SRWS.RWST r w s m) where
   getSession = lift getSession
   putSession = lift . putSession

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -51,7 +51,7 @@ Library
                  , bytestring >= 0.9 && < 0.11
                  , attoparsec >= 0.10 && < 0.14
                  , base64-bytestring >= 1.0 && < 1.1
-                 , transformers >= 0.2 && < 0.5
+                 , transformers >= 0.4 && < 0.5
                  , monad-control >= 0.3 && < 1.1
                  , transformers-base >= 0.1 && < 1.0
                  , lifted-base >= 0.1 && < 0.3


### PR DESCRIPTION
Hello there

I though these instances would be better in here than hidden in my code :)

ExceptT was added in transformers-4.0, so I bumped the bound. If that's a problem, I can pull the transformers-compat to keep compatibilitu with old tranformers.

Thanks a lot!