### PR TITLE
Update links in the documentation

### DIFF
--- a/examples/readme-example-beginner.md
+++ b/examples/readme-example-beginner.md
@@ -65,7 +65,7 @@ browser.
 
 *Note*: To use Google Chrome, you need to install Google's proprietary
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) in a directory where it can be recognized by Selenium
-Server (see: https://code.google.com/p/selenium/wiki/ChromeDriver). When using propriertary webdrivers such as chromedriver,
+Server (see: https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver). When using propriertary webdrivers such as chromedriver,
 Selenium Server simply acts as a proxy server, automatically spawning a proprietary server process as needed. Because of
 this extra installation step, we simply use the `firefoxConfig` for the remainder of the example.
 

--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -353,7 +353,7 @@ data Browser = Firefox { -- |The firefox profile to use. If Nothing,
              | Chrome { -- |Version of the Chrome Webdriver server server to use
                         --
                         -- for more information on chromedriver see
-                        -- <http://code.google.com/p/selenium/wiki/ChromeDriver>
+                        -- <https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver>
                         chromeDriverVersion :: Maybe String
                         -- |Server-side path to Chrome binary. If Nothing,
                         -- use a sensible system-based default.

--- a/src/Test/WebDriver/Class.hs
+++ b/src/Test/WebDriver/Class.hs
@@ -36,7 +36,7 @@ import Control.Monad.Trans.RWS.Lazy as LRWS
 -- |A class for monads that can handle wire protocol requests. This is the
 -- operation underlying all of the high-level commands exported in
 -- "Test.WebDriver.Commands". For more information on the wire protocol see
--- <http://code.google.com/p/selenium/wiki/JsonWireProtocol>
+-- <https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol>
 class (WDSessionStateControl wd) => WebDriver wd where
   doCommand :: (ToJSON a, FromJSON b) =>
                    Method      -- ^HTTP request method

--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -452,7 +452,7 @@ getText e = doElemCommand methodGet e "/text" Null
 
 -- |Send a sequence of keystrokes to an element. All modifier keys are released
 -- at the end of the function. For more information about modifier keys, see
--- <http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value>
+-- <https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidvalue>
 sendKeys :: WebDriver wd => Text -> Element -> wd ()
 sendKeys t e = noReturn . doElemCommand methodPost e "/value" . single "value" $ [t]
 
@@ -741,7 +741,7 @@ doStorageCommand m s path a = doSessCommand m (T.concat ["/", s', path]) a
 
 -- |Get information from the server as a JSON 'Object'. For more information
 -- about this object see
--- <http://code.google.com/p/selenium/wiki/JsonWireProtocol#/status>
+-- <https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#status>
 serverStatus :: (WebDriver wd) => wd Value   -- todo: make this a record type
 serverStatus = doCommand methodGet "/status" Null
 

--- a/src/Test/WebDriver/Commands/Internal.hs
+++ b/src/Test/WebDriver/Commands/Internal.hs
@@ -65,7 +65,7 @@ newtype NoSessionId = NoSessionId String
 -- the session URL parameter to the wire command URL. For example, passing
 -- a URL of \"/refresh\" will expand to \"/session/:sessionId/refresh\", where
 -- :sessionId is a URL parameter as described in
--- <http://code.google.com/p/selenium/wiki/JsonWireProtocol>
+-- <https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol>
 doSessCommand :: (WebDriver wd, ToJSON a, FromJSON b) =>
                   Method -> Text -> a -> wd b
 doSessCommand method path args = do


### PR DESCRIPTION
A few links in the documentation are broken. I changed the old links related to `google code` for the new ones that are related to `github wiki`.