### PR TITLE
Remove duplicated Content-Length header

### DIFF
--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -72,8 +72,7 @@ mkRequest meth wdPath args = do
     , requestBody = RequestBodyLBS body
     , requestHeaders = wdSessRequestHeaders
                        ++ [ (hAccept, "application/json;charset=UTF-8")
-                          , (hContentType, "application/json;charset=UTF-8")
-                          , (hContentLength, fromString . show . LBS.length $ body) ]
+                          , (hContentType, "application/json;charset=UTF-8") ]
     , method = meth }
 
 -- |Sends an HTTP request to the remote WebDriver server


### PR DESCRIPTION
Duplicated Content-Length header causes error on ChromeDriver server for android.

See also: https://hackage.haskell.org/package/http-client-0.3.0/docs/src/Network-HTTP-Client-Types.html#line-302

> The Content-Length and Transfer-Encoding headers are set automatically
> by this module, and shall not be added to @requestHeaders@.