### PR TITLE
Fix http-client > 0.5.

### DIFF
--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -74,7 +74,10 @@ mkRequest meth wdPath args = do
                        ++ [ (hAccept, "application/json;charset=UTF-8")
                           , (hContentType, "application/json;charset=UTF-8") ]
     , method = meth 
-    , checkStatus = \_ _ _ -> Nothing }
+#if !MIN_VERSION_http_client(0,5,0)
+    , checkStatus = \_ _ _ -> Nothing
+#endif
+    }
 
 -- |Sends an HTTP request to the remote WebDriver server
 sendHTTPRequest :: (WDSessionStateIO s) => Request -> s (Either SomeException (Response ByteString))

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -45,7 +45,7 @@ Library
     cpp-options: -DCABAL_BUILD_DEVELOPER
   build-depends:   base == 4.*
                  , aeson >= 0.6.2.0
-                 , http-client >= 0.3 && < 0.5
+                 , http-client >= 0.3
                  , http-types >= 0.8
                  , text >= 0.11.3
                  , bytestring >= 0.9


### PR DESCRIPTION
This adds an ifdef and only puts in `checkStatus` for older versions of http-client. In newer versions the default is already to do nothing.