### PR TITLE
Parse as floating numbers

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -516,11 +516,11 @@ cssProp :: WebDriver wd => Element -> Text -> wd (Maybe Text)
 cssProp e t = doElemCommand methodGet e ("/css/" `append` urlEncode t) Null
 
 -- |Retrieve an element's current position.
-elemPos :: WebDriver wd => Element -> wd (Int, Int)
+elemPos :: WebDriver wd => Element -> wd (Float, Float)
 elemPos e = doElemCommand methodGet e "/location" Null >>= parsePair "x" "y" "elemPos"
 
 -- |Retrieve an element's current size.
-elemSize :: WebDriver wd => Element -> wd (Word, Word)
+elemSize :: WebDriver wd => Element -> wd (Float, Float)
 elemSize e = doElemCommand methodGet e "/size" Null
              >>= parsePair "width" "height" "elemSize"
 


### PR DESCRIPTION
Ref: https://github.com/kallisti-dev/hs-webdriver/issues/131

This commit fixes out tests (as long as we update our types to support `Float`).

Sorry this took far too long to get around to for such a tiny commit!