### PR TITLE
Export `ExpectFailed` constructor

### DIFF
--- a/src/Test/WebDriver/Commands/Wait.hs
+++ b/src/Test/WebDriver/Commands/Wait.hs
@@ -4,7 +4,7 @@ module Test.WebDriver.Commands.Wait
          waitUntil, waitUntil'
        , waitWhile, waitWhile'
          -- * Expected conditions
-       , ExpectFailed, expect, unexpected
+       , ExpectFailed (..), expect, unexpected
        , expectAny, expectAll
        , expectNotStale, expectAlertOpen
        , catchFailedCommand


### PR DESCRIPTION
This is needed when using unexpected to throw one of these and then you catch it somewhere else and want to get the String out