### PR TITLE
Fix travis build by using cabal-install-1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.4.2
+    - env: CABALVER=1.18 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}


### PR DESCRIPTION
New versions of Aeson fails to compile with cabal-install-1.16. So it should be updated to cabal-install-1.18.

Related issue & changes in other repositories:
- https://github.com/bos/aeson/issues/533
- https://github.com/peti/package-list/commit/848b241da42eb4e320e9c04bb32f0a6a83e0277e

Error log in Travis:
```
Data/Aeson/Encoding/Internal.hs:211:40:
    No instance for (Semigroup Builder) arising from a use of `<>'
    Possible fix: add an instance declaration for (Semigroup Builder)
    In the first argument of `Encoding', namely `(a <> b)'
    In the expression: Encoding (a <> b)
    In an equation for `><':
        (Encoding a) >< (Encoding b) = Encoding (a <> b)
Data/Aeson/Encoding/Internal.hs:230:17:
    No instance for (Semigroup Builder) arising from a use of `<>'
    Possible fix: add an instance declaration for (Semigroup Builder)
    In the second argument of `($)', namely
      `char7 '"'
       <> LT.foldrChunks (\ x xs -> EB.unquoted x <> xs) (char7 '"') t'
    In the expression:
      Encoding
      $ char7 '"'
        <> LT.foldrChunks (\ x xs -> EB.unquoted x <> xs) (char7 '"') t
    In an equation for `lazyText':
        lazyText t
          = Encoding
            $ char7 '"'
              <> LT.foldrChunks (\ x xs -> EB.unquoted x <> xs) (char7 '"') t
Failed to install aeson-1.2.3.0
```