### PR TITLE
Removes broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ tested with `selenium-server-standalone-2.53.1`.
 ## Hello, World!
 With the Selenium server running locally, you're ready to write browser automation scripts in Haskell.
 
-A [simple example can be found here](/examples/readme-example-beginner.md), written in literate Haskell so that you can compile it with GHC yourself. It is very beginner friendly and assumes no prior knowledge of Haskell. If you already have an intermediate understanding of Haskell, [this is the example for you](/examples/readme-example-intermediate.md) For other examples see the [examples](examples/) and [test/etc](test/etc/) directory.
+A [simple example can be found here](/examples/readme-example-beginner.md), written in literate Haskell so that you can compile it with GHC yourself. It is very beginner friendly and assumes no prior knowledge of Haskell. For other examples see the [examples](examples/) and [test/etc](test/etc/) directory.
 
 
 # Integration with Haskell Testing Frameworks


### PR DESCRIPTION
Removes the sentence that references the intermediate example
because that example is not in the codebase.