### PR TITLE
noReturn --> ignoreReturn in closeWindow

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -313,7 +313,7 @@ closeWindow :: (HasCallStack, WebDriver wd) => WindowHandle -> wd ()
 closeWindow w = do
   cw <- getCurrentWindow
   focusWindow w
-  noReturn $ doSessCommand methodDelete "/window" Null
+  ignoreReturn $ doSessCommand methodDelete "/window" Null
   unless (w == cw) $ focusWindow cw
 
 -- |Maximizes the current  window if not already maximized


### PR DESCRIPTION
This caused a `BadJSON` crash for me with chromedriver 2.45. Apparently the close window endpoint sometimes returns a value.

I think this makes sense in view of the [webdriver spec](https://w3c.github.io/webdriver/#close-window).