### PR TITLE
Resolve #136: Accept "element-6066-11e4-a52e-4f735466cecf" as well as "ELEMENT"

### DIFF
--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -234,7 +234,7 @@ instance ToJSON Capabilities where
                 ,"opera.autostart" .= operaAutoStart
                 , "opera.idle" .= operaIdle
                 -- ,"opera.profile" .= operaProfile
-                ,"opera.port" .= fromMaybe (-1) operaPort
+                ,"opera.port" .= fromMaybe maxBound {- (-1) -} operaPort
                  --note: consider replacing operaOptions with a list of options
                 ,"opera.arguments" .= operaOptions
                 ,"opera.logging.level" .= operaLogPref
@@ -702,6 +702,7 @@ instance ToJSON LogLevel where
     LogFine -> "FINE"
     LogFiner -> "FINER"
     LogFinest -> "FINEST"
+    LogDebug -> "DEBUG"
     LogAll -> "ALL"
 
 instance FromJSON LogLevel where

--- a/src/Test/WebDriver/Commands/Internal.hs
+++ b/src/Test/WebDriver/Commands/Internal.hs
@@ -37,7 +37,7 @@ newtype Element = Element Text
                   deriving (Eq, Ord, Show, Read)
 
 instance FromJSON Element where
-  parseJSON (Object o) = Element <$> o .: "ELEMENT"
+  parseJSON (Object o) = Element <$> (o .: "ELEMENT" <|> o .: "element-6066-11e4-a52e-4f735466cecf")
   parseJSON v = typeMismatch "Element" v
 
 instance ToJSON Element where

--- a/src/Test/WebDriver/Exceptions/Internal.hs
+++ b/src/Test/WebDriver/Exceptions/Internal.hs
@@ -21,13 +21,9 @@ import qualified Data.Text.Lazy.Encoding as TLE
 import Control.Applicative
 import Control.Exception (Exception)
 import Control.Exception.Lifted (throwIO)
-import Control.Monad.IO.Class
 
 import Data.Maybe (fromMaybe, catMaybes)
 import Data.Typeable (Typeable)
-import Data.Word
-
-import Debug.Trace
 
 import Prelude -- hides some "unused import" warnings
 

--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -24,7 +24,7 @@ import Network.HTTP.Types.Status (Status(..))
 import qualified Data.ByteString.Base64.Lazy as B64
 import qualified Data.ByteString.Char8 as BS
 import Data.ByteString.Lazy.Char8 (ByteString)
-import Data.ByteString.Lazy.Char8 as LBS (length, unpack, null)
+import Data.ByteString.Lazy.Char8 as LBS (unpack, null)
 import qualified Data.ByteString.Lazy.Internal as LBS (ByteString(..))
 import Data.CallStack
 import Data.Text as T (Text, splitOn, null)


### PR DESCRIPTION
Resolves #136

Nice to meet you!

This PR modifies `instance FromJSON Element` so that it accepts `"element-6066-11e4-a52e-4f735466cecf"` as well as `"ELEMENT"`.

This is a quick-fix which doesn't really try to adhere to the W3C protocol, unlike #144. That said, this fix improves the situation with Firefox from "not working at all" to "somehow working". Also, it's what the official Python remote webdriver appears to be doing: [remote/webdriver.py][python-webdriver]

If interested, [here][gist] is the script I used.

This PR includes a couple of other fixes which address the compiler warnings.

[python-webdriver]: https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/remote/webdriver.py#L280
[gist]: https://gist.github.com/matil019/652688e1762291473eb2458dcf422c56
