### PR TITLE
Correct the method of the "maximize" command to POST

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -318,7 +318,7 @@ closeWindow w = do
 
 -- |Maximizes the current  window if not already maximized
 maximize :: (HasCallStack, WebDriver wd) => wd ()
-maximize = noReturn $ doWinCommand methodGet currentWindow "/maximize" Null
+maximize = ignoreReturn $ doWinCommand methodPost currentWindow "/maximize" Null
 
 -- |Get the dimensions of the current window.
 getWindowSize :: (HasCallStack, WebDriver wd) => wd (Word, Word)


### PR DESCRIPTION
The `maximize` command expects the `POST` method, not the `GET` method.

- [W3C](https://w3c.github.io/webdriver/#maximize-window)
- [OSS](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidwindowwindowhandlemaximize) (obsolete)
