### PR TITLE
Fix Cookie ToJSON instance

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -819,4 +819,4 @@ getApplicationCacheStatus = doSessCommand methodGet "/application_cache/status" 
 
 -- Moving this closer to the definition of Cookie seems to cause strange compile
 -- errors, so I'm leaving it here for now.
-$( deriveToJSON (defaultOptions{fieldLabelModifier = map C.toLower . drop 4}) ''Cookie )
+$( deriveToJSON (defaultOptions{omitNothingFields = True, fieldLabelModifier = map C.toLower . drop 4}) ''Cookie )


### PR DESCRIPTION
The docs say "When sending cookies to the server, a value of Nothing indicates that the server should use a default value." That was not actually working for me -- for example, I sent a cookie with `cookDomain = Nothing`, and it caused a Selenium exception `FailedCommand UnknownError` with `<unknown exception>: invalid argument: invalid 'domain'`.

It seems this happened because `Cookie` was serialized to JSON with `Nothing` values converted to `null`, which Selenium didn't like. This PR flips on the Aeson `omitNothingFields` flag to fix that.