### PR TITLE
Another couple noReturn -> ignoreReturn

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -327,7 +327,7 @@ getWindowSize = doWinCommand methodGet currentWindow "/size" Null
 
 -- |Set the dimensions of the current window.
 setWindowSize :: (HasCallStack, WebDriver wd) => (Word, Word) -> wd ()
-setWindowSize = noReturn . doWinCommand methodPost currentWindow "/size"
+setWindowSize = ignoreReturn . doWinCommand methodPost currentWindow "/size"
                 . pair ("width", "height")
 
 -- |Get the coordinates of the current window.
@@ -337,7 +337,7 @@ getWindowPos = doWinCommand methodGet currentWindow "/position" Null
 
 -- |Set the coordinates of the current window.
 setWindowPos :: (HasCallStack, WebDriver wd) => (Int, Int) -> wd ()
-setWindowPos = noReturn . doWinCommand methodPost currentWindow "/position" . pair ("x","y")
+setWindowPos = ignoreReturn . doWinCommand methodPost currentWindow "/position" . pair ("x","y")
 
 -- |Cookies are delicious delicacies. When sending cookies to the server, a value
 -- of Nothing indicates that the server should use a default value. When receiving


### PR DESCRIPTION
This is another change exactly like #151.

I'm wondering, is there a specific webdriver spec that this library is targeting? Like a document that explains which endpoints are supposed to return values and stuff. I saw [this](https://w3c.github.io/webdriver/) but wasn't sure what version to look at. 

It would be helpful to find an authoritative source on how each endpoint should be treated rather than just squashing bugs like this. (Or perhaps it would be a good idea to just use `ignoreReturn` instead of `noReturn` always.)